### PR TITLE
Fix: breaking hash-sig-cli image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,15 @@ FROM rust:1.87 AS builder
 
 WORKDIR /usr/src/hash-sig-cli
 
+# Copy manifest and pre-fetch dependencies (cached if unchanged)
 COPY Cargo.toml ./
-
-# Create a new empty shell project to cache dependencies
 RUN mkdir src && echo "fn main() {}" > src/main.rs
+RUN cargo fetch
+RUN rm -rf src
 
-# Build the dependencies
-RUN cargo build --release
-RUN rm -f target/release/deps/hash_sig_cli*
-
-# Copy the source code
-COPY . .
-
-# Build the actual application
-RUN cargo build --release
+# Copy actual sources and build the binary
+COPY src ./src
+RUN cargo build --release --bin hashsig
 
 # Use a smaller base image for the final image
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Description
  Fix the hash-sig-cli Docker image so it ships the real CLI binary. The previous image ran but produced no keys/manifest, breaking downstream flows (e.g., lean-quickstart reported missing validator-keys-manifest.yaml).

  ## Root Cause
  The Dockerfile built a dummy `fn main() {}` for dependency caching and that artifact was copied into the final image; the real build was skipped due to cache, so the entrypoint was a no-op.

  ## Fix
  Remove the dummy src before copying real sources and rebuild `hashsig`, ensuring the final image contains the actual CLI.

  ## Validation
  - `docker build --no-cache -t hashsig-cli .`
  - `docker run --rm -it hashsig-cli --help`
  - `docker run --rm -it -v "$(pwd)/generated_keys:/output" hashsig-cli generate --num-validators 1 --log-num-active-epochs 10 --output-dir /output` (keys + manifest produced)
  - Built and ran on AWS EC2 host (amd64, Ubuntu 24.04 - same as the github runner) with matching results.
  - Also tested with changes from https://github.com/blockblaz/hash-sig-cli/pull/28